### PR TITLE
HashiCorp has rotated its release signing key as a part of HCSEC-2021-12

### DIFF
--- a/exercise_1/main.tf
+++ b/exercise_1/main.tf
@@ -2,6 +2,7 @@ provider "aws" {
   access_key = "${var.access_key}"
   secret_key = "${var.secret_key}"
   region = "${var.region}"
+  version = "v2.70.0"
 }
 
 resource "aws_s3_bucket" "tf-root-module-bucket" {


### PR DESCRIPTION
https://stackoverflow.com/questions/67368339/error-installing-provider-aws-openpgp-signature-made-by-unknown-entity